### PR TITLE
Fix: 이미지 생성 결과 dto에 사용자가 입력한 키워드 + 추출된 키워드 리스트 추가

### DIFF
--- a/src/main/java/com/backend/sparkle/dto/MessageDto.java
+++ b/src/main/java/com/backend/sparkle/dto/MessageDto.java
@@ -28,7 +28,7 @@ public class MessageDto {
         @Schema(description = "계절감 키워드", example = "봄")
         private String season;
 
-        @Schema(description = "사용자가 직접 입력된 키워드", example = "[\"립스틱\", \"향수병\", \"여성스러운 분위기\"]")
+        @Schema(description = "사용자가 직접 입력한 키워드", example = "[\"립스틱\", \"향수병\", \"여성스러운 분위기\"]")
         private List<String> keyWordMessage;
     }
 
@@ -42,6 +42,9 @@ public class MessageDto {
                         "\"https://i.pinimg.com/564x/38/73/51/387351a404a2dcf47ada6a138b7a14e7.jpg\", " +
                         "\"https://i.pinimg.com/564x/f0/e0/9c/f0e09cba73d689fc2c0ef01bbbbeae1a.jpg\"]")
         private List<String> generatedImageUrls;
+
+        @Schema(description = "사용자가 직접 입력한 키워드 + 추출된 키워드, 템플릿 이미지 삽입 시 unsplash를 통해 이미지를 가져올 때 해당 키워드를 바탕으로 이미지를 가져온다", example = "[\"립스틱\", \"향수\", \"여성스러운 분위기\"]")
+        private List<String> keyWord;
     }
 
     @Getter
@@ -60,7 +63,7 @@ public class MessageDto {
         private String sendPhoneNumber;
 
         @Schema(description = "주소록 별칭", example = "김선생 영어학원 주소록")
-        private String addressName;
+        private String addressName;;
     }
 
     @Getter
@@ -72,7 +75,6 @@ public class MessageDto {
         @Schema(description = "선택된 이미지 URL 경로",
                 example = "https://i.pinimg.com/564x/f0/e0/9c/f0e09cba73d689fc2c0ef01bbbbeae1a.jpg")
         private String selectedImageURL;
-
 
         @Schema(description = "발신번호 목록", example = "[\"010-0000-0000\", \"010-1234-5678\", \"010-5678-1234\"]")
         private List<String> sendPhoneNumbers;

--- a/src/main/java/com/backend/sparkle/service/ImageService.java
+++ b/src/main/java/com/backend/sparkle/service/ImageService.java
@@ -27,6 +27,8 @@ public class ImageService {
     private final WebClient webClient;
     private final BlobService blobService;
 
+    private final TextAnalyticsService textAnalyticsService;
+
     @Value("${azure.dalle.endpoint}")
     private String dalleAzureEndpoint;
 
@@ -48,9 +50,10 @@ public class ImageService {
 
     // WebClient와 BlobService를 생성자 주입을 통해 초기화
     @Autowired
-    public ImageService(WebClient.Builder webClientBuilder, BlobService blobService) {
+    public ImageService(WebClient.Builder webClientBuilder, BlobService blobService, TextAnalyticsService textAnalyticsService) {
         this.webClient = webClientBuilder.build();
         this.blobService = blobService;
+        this.textAnalyticsService=textAnalyticsService;
     }
 
     // 서비스 초기화 시 DALL-E API URI 설정
@@ -83,6 +86,7 @@ public class ImageService {
 
         return MessageDto.ImageGenerateResponseDto.builder()
                 .generatedImageUrls(generatedImageUrls)
+                .keyWord(textAnalyticsService.extractKeyPhrases(requestDto.getInputMessage(), requestDto.getKeyWordMessage()))
                 .build();
     }
 

--- a/src/main/java/com/backend/sparkle/service/TextAnalyticsService.java
+++ b/src/main/java/com/backend/sparkle/service/TextAnalyticsService.java
@@ -38,25 +38,23 @@ public class TextAnalyticsService {
                 .credential(new AzureKeyCredential(cognitiveApiKey))
                 .endpoint(cognitiveAzureEndpoint)
                 .buildClient();
-        
+
         log.info("TextAnalyticsClient 생성 완료");
     }
 
     // Azure의 textAnalytics를 이용하여 핵심 사용자가 입력한 발송 목적 및 내용에서 키워드를 추출하는 메서드
-    public List<String> extractKeyPhrases(MessageDto.ImageGenerateRequestDto requestDto) {
-        // KeyPhrasesCollection을 반환하며, 이를 List<String>으로 변환
+    public List<String> extractKeyPhrases(String inputMessage, List<String> keyWordMessage) {
         List<String> keyPhrases = new ArrayList<>();
 
-        textAnalyticsClient.extractKeyPhrases(chatGptService.translateText(requestDto.getInputMessage())).forEach(keyPhrase -> {
-            keyPhrases.add(keyPhrase); // 키워드 추가
-            log.info("추출된 키워드: {}", keyPhrase); // 키워드 출력
+        // 사용자가 직접 입력한 키워드 리스트 추가
+        keyPhrases.addAll(keyWordMessage);
+
+        // Azure 텍스트 분석 API를 사용해 영어 키워드 추출 후, 한국어로 번역하여 리스트에 추가
+        textAnalyticsClient.extractKeyPhrases(chatGptService.translateText(inputMessage, "en")).forEach(keyPhrase -> {
+            String translatedKeyPhrase = chatGptService.translateText(keyPhrase, "kr");
+            keyPhrases.add(translatedKeyPhrase); // 번역된 키워드 추가
+            log.info("추출된 키워드 (한국어): {}", translatedKeyPhrase);
         });
-
-
-//        textAnalyticsClient.extractKeyPhrases(requestDto.getInputMessage()).forEach(keyPhrase -> {
-//            keyPhrasesList.add(keyPhrase); // 키워드 추가
-//            log.info("추출된 키워드: {}", keyPhrase); // 키워드 출력
-//        });
 
         log.info("키워드 추출 완료");
 


### PR DESCRIPTION
## 📝 설명

템플릿 기능의 이미지 삽입에서는 추출된 키워드와 사용자가 입력한 키워드를 기반으로 Unsplash API에서 이미지를 제공하기 때문에, 생성된 이미지에 해당 이미지를 부착할 수 있도록 MessageDto.ImageGenerateResponseDto(이미지 생성 결과 DTO)에 private List<String> keyWord 필드를 추가.

## 💡 PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


##  ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
