### PR TITLE
[Feat]: 발송 목적 및 내용 기반 광고 문자 생성 추가

### DIFF
--- a/src/main/java/com/backend/sparkle/controller/MessageSendController.java
+++ b/src/main/java/com/backend/sparkle/controller/MessageSendController.java
@@ -44,21 +44,21 @@ public class MessageSendController {
     }
 
     @Operation(
-            summary = "발송 목적 및 내용, 키워드 선택(분위기, 계절감), 키워드 입력 후 이미지 생성",
-            description = "사용자가 발송 목적 및 내용, 키워드 선택(분위기, 계절감), 키워드 입력 후 이미지 생성하기 버튼을 클릭하여 4개의 이미지를 생성",
+            summary = "발송 목적 및 내용, 키워드 선택(분위기, 계절감), 키워드 입력 후 이미지 및 광고 문자 생성",
+            description = "사용자가 발송 목적 및 내용, 키워드 선택(분위기, 계절감), 키워드 입력 후 이미지 생성하기 버튼을 클릭하여 3개의 이미지와 광고 문자 생성",
             parameters = {
                     @Parameter(name = "userId", description = "사용자 PK", required = true, example = "1")
             }
     )
     @PostMapping("/generate/{userId}")
-    public ResponseEntity<CommonResponse<MessageDto.ImageGenerateResponseDto>> createImages(@PathVariable Long userId, @RequestBody MessageDto.ImageGenerateRequestDto requestDto) {
+    public ResponseEntity<CommonResponse<MessageDto.GeneratedImageMessageResponseDto>> createImages(@PathVariable("userId") Long userId, @RequestBody MessageDto.ImageGenerateRequestDto requestDto) {
         log.info("이미지 생성 요청 userId: {}", userId);
         try {
-            MessageDto.ImageGenerateResponseDto responseDto = imageService.generateImages(requestDto);
+            MessageDto.GeneratedImageMessageResponseDto responseDto = imageService.generateImages(requestDto);
             return ResponseEntity.ok(CommonResponse.success("이미지 생성 성공", responseDto));
         } catch (WebClientResponseException e) {
             log.error("Azure Dalle 이미지 생성 요청 오류: {}", e.getMessage());
-            return ResponseEntity.status(e.getStatusCode()).body(CommonResponse.fail("Azure Dalle 이미지 생성 요청 오류"));
+            return ResponseEntity.status(e.getStatusCode()).body(CommonResponse.fail(e.getMessage()));
         }  catch (Exception e) {
             log.error("이미지 생성 실패: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(CommonResponse.fail(e.getMessage()));
@@ -74,7 +74,7 @@ public class MessageSendController {
     )
     @PostMapping(value = "/send/{userId}", consumes = {"multipart/form-data"})
     public ResponseEntity<CommonResponse<Long>> sendUnifiedMessage(
-            @PathVariable Long userId,
+            @PathVariable("userId") Long userId,
             @RequestPart("file") MultipartFile file,
             @RequestPart("requestDto") String requestDtoJson) {
 
@@ -138,7 +138,6 @@ public class MessageSendController {
         return phoneNumbers;
     }
 
-
     // 문자 발송 완료 후 화면
     @Operation(
             summary = "문자 보내기 완료 후",
@@ -148,7 +147,7 @@ public class MessageSendController {
             }
     )
     @GetMapping("/complete/{userId}")
-    public ResponseEntity< CommonResponse<MessageDto.SendCompleteResponseDto> > getSendCompleteResponse (@PathVariable Long userId){
+    public ResponseEntity< CommonResponse<MessageDto.SendCompleteResponseDto> > getSendCompleteResponse (@PathVariable("userId") Long userId){
         try {
             return ResponseEntity.ok(CommonResponse.success("문자 보내기 완료 후 요청 성공", messageService.getSendCompleteMessage(userId)));
         } catch (NoSuchElementException e){
@@ -157,7 +156,6 @@ public class MessageSendController {
                     .body(CommonResponse.fail("문자 보내기 완료 후 요청 실패"));
         }
     }
-
 
     // 테스트 발송 메서드 추가
     @Operation(
@@ -168,7 +166,7 @@ public class MessageSendController {
             }
     )
     @PostMapping("/test/{userId}")
-    public ResponseEntity<CommonResponse<Long>> sendTestMessage(@PathVariable Long userId, @RequestBody MessageDto.SendRequestDto requestDto) {
+    public ResponseEntity<CommonResponse<Long>> sendTestMessage(@PathVariable("userId") Long userId, @RequestBody MessageDto.SendRequestDto requestDto) {
         try {
             log.info("테스트 문자 발송 요청 userId: {}", userId);
 

--- a/src/main/java/com/backend/sparkle/dto/MessageDto.java
+++ b/src/main/java/com/backend/sparkle/dto/MessageDto.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.List;
 
 public class MessageDto {
@@ -36,13 +34,16 @@ public class MessageDto {
     @Builder
     @AllArgsConstructor
     @Schema(description = "이미지 생성 응답 정보")
-    public static class ImageGenerateResponseDto {
+    public static class GeneratedImageMessageResponseDto {
         @Schema(description = "생성된 4장의 이미지 URL 경로 리스트",
                 example = "[\"https://sparcleblob.blob.core.windows.net/test-blob/uploaded_image_1730195858730.png\", " +
                         "\"https://sparcleblob.blob.core.windows.net/test-blob/uploaded_image_1730195859420.png\", " +
                         "\"https://sparcleblob.blob.core.windows.net/test-blob/uploaded_image_1730195859651.png\", " +
                         "\"https://sparcleblob.blob.core.windows.net/test-blob/uploaded_image_1730195858740.png\"]")
         private List<String> generatedImageUrls;
+
+        @Schema(description = "생성된 광고 메시지", example ="")
+        private String advertiseMessage;
     }
 
     @Getter

--- a/src/main/java/com/backend/sparkle/service/ChatGptService.java
+++ b/src/main/java/com/backend/sparkle/service/ChatGptService.java
@@ -81,7 +81,7 @@ public class ChatGptService {
 
             if (choicesNode.isArray() && choicesNode.size() > 0) {
                 String content = choicesNode.get(0).path("message").path("content").asText();
-                log.error(content);
+                log.info(content);
                 if (!content.isEmpty()) {
                     return content;
                 }

--- a/src/main/java/com/backend/sparkle/service/ImageService.java
+++ b/src/main/java/com/backend/sparkle/service/ImageService.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -28,10 +27,9 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 public class ImageService {
-
     private final WebClient webClient;
     private final BlobService blobService;
-    private final ChatGPTService chatGptService;
+    private final ChatGptService chatGptService;
     private final TextAnalyticsService textAnalyticsService;
 
     @Value("${azure.dalle.endpoint}")
@@ -45,7 +43,7 @@ public class ImageService {
 
     private String dalleURI;
 
-    // 이미지 생성에 사용될 다양한 스타일 목록 정의
+    // 이미지 생성에 사용될 다양한 스타일 목록 정의 - 일러스트, 사실적, 애니메이션
     private static final List<String> styles = List.of(
             "Minimalist illustration style with pastel tones, featuring a simple and clean composition with soft shading",
             "Highly detailed and realistic photographic style, a high-resolution image with vivid realism and fine detail",
@@ -53,7 +51,7 @@ public class ImageService {
     );
 
     @Autowired
-    public ImageService(WebClient.Builder webClientBuilder, BlobService blobService, ChatGPTService chatGptService, TextAnalyticsService textAnalyticsService) {
+    public ImageService(WebClient.Builder webClientBuilder, BlobService blobService, ChatGptService chatGptService, TextAnalyticsService textAnalyticsService) {
         this.webClient = webClientBuilder.build();
         this.blobService = blobService;
         this.chatGptService = chatGptService;
@@ -66,22 +64,30 @@ public class ImageService {
     }
 
     // 이미지 생성 요청 메소드
-    public MessageDto.ImageGenerateResponseDto generateImages(MessageDto.ImageGenerateRequestDto requestDto) {
+    public MessageDto.GeneratedImageMessageResponseDto generateImages(MessageDto.ImageGenerateRequestDto requestDto) {
+        // 분위기, 계졀 키워드 영어로 변환
         MoodStrategy styleStrategy = MoodStrategyFactory.getMoodStrategy(requestDto.getMood());
         SeasonStrategy seasonStrategy = SeasonStrategyFactory.getSeasonStrategy(requestDto.getSeason());
 
         String transformedMood = styleStrategy.applyMood();
         String transformedSeason = seasonStrategy.applySeason();
+        
+        // 광고 메시지 생성
+        String advertiseMessage = chatGptService.generateMessage(requestDto.getInputMessage());
+        log.info("생성된 광고 메시지: {}", advertiseMessage);
 
+        // 발송 목적 및 내용 영어로 변환
         List<String> keyPhrases = requestDto.getKeyWordMessage().stream()
                 .map(keyword -> chatGptService.translateText(keyword, "en"))
                 .collect(Collectors.toList());
 
+        // Azure Text Analytics를 이용하여 키워드 추출
         keyPhrases.addAll(textAnalyticsService.extractKeyPhrases(requestDto.getInputMessage()));
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         LocalDateTime startTime = LocalDateTime.now();
 
+        // Dalle 이미지 생성 비동기로 요청
         List<CompletableFuture<String>> imageFutures = styles.parallelStream()
                 .map(style -> retryGenerateImage(style, keyPhrases, requestDto.getInputMessage(), transformedMood, transformedSeason))
                 .collect(Collectors.toList());
@@ -98,8 +104,9 @@ public class ImageService {
             Duration duration = Duration.between(startTime, endTime);
             log.info("Dalle 이미지 생성 소요 시간: {} 초", duration.getSeconds());
 
-            return MessageDto.ImageGenerateResponseDto.builder()
+            return MessageDto.GeneratedImageMessageResponseDto.builder()
                     .generatedImageUrls(generatedImageUrls)
+                    .advertiseMessage(advertiseMessage)
                     .build();
         }).join();
     }
@@ -169,6 +176,7 @@ public class ImageService {
         });
     }
 
+    // Dalle 요청 프롬프트 생성
     private String generatePrompt(String imageStyle, List<String> keyPhrases, String inputMessage, String mood, String season) {
         return String.format(
                 "Please create an image in a %s style. The image should emphasize a clean and minimalist design and layout. " +

--- a/src/main/java/com/backend/sparkle/service/ImageService.java
+++ b/src/main/java/com/backend/sparkle/service/ImageService.java
@@ -183,7 +183,7 @@ public class ImageService {
                         "Text and human figures must not be included, and absolutely no letters or characters should appear in the image. " +
                         "Description: %s. " +
                         "Visually express the following keywords: %s. Set the mood to %s and reflect this atmosphere in the image. " +
-                        "The background should be based on a %s seasonal theme, kept simple in a solid color. Exclude any complex background elements. " +
+                        "The background should be based on a %s seasonal theme, kept simple in a solid color. Ensure that the background does not include any text, letters, or characters, and excludes complex background elements. " +
                         "The background should not contain any elements other than the objects described and the keywords.",
                 imageStyle,
                 chatGptService.translateText(inputMessage, "en"),
@@ -191,5 +191,19 @@ public class ImageService {
                 mood,
                 season
         );
+
+//    private String generatePrompt(String imageStyle, List<String> keyPhrases, String inputMessage, String mood, String season) {
+//        return String.format(
+//                "Create a clean and minimalist image in a %s style. The design should avoid any text, letters, or human figures. " +
+//                        "Description: %s. " +
+//                        "Focus on visually expressing these keywords: %s. Set the mood to %s to reflect this atmosphere in the image. " +
+//                        "Use a simple, solid-colored background inspired by a %s seasonal theme, without including text or complex elements. " +
+//                        "Only include the objects and keywords described.",
+//                imageStyle,
+//                chatGptService.translateText(inputMessage, "en"),
+//                String.join(", ", keyPhrases),
+//                mood,
+//                season
+//        );
     }
 }

--- a/src/main/java/com/backend/sparkle/service/MessageService.java
+++ b/src/main/java/com/backend/sparkle/service/MessageService.java
@@ -8,11 +8,13 @@ import com.backend.sparkle.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
 import java.util.NoSuchElementException;
 
 @Slf4j
+@Transactional(readOnly = true)
 @Service
 public class MessageService {
     private final MessageRepository messageRepository;
@@ -27,6 +29,7 @@ public class MessageService {
     }
     
     // 사용자가 전송한 메시지 내역 저장
+    @Transactional
     public void addMessage(Long userId, MessageDto.SendRequestDto requestDto){
         // User 객체 조회
         User user = userRepository.findById(userId)

--- a/src/main/java/com/backend/sparkle/service/TextAnalyticsService.java
+++ b/src/main/java/com/backend/sparkle/service/TextAnalyticsService.java
@@ -17,7 +17,7 @@ public class TextAnalyticsService {
 
     private TextAnalyticsClient textAnalyticsClient; // 텍스트 분석 클라이언트
 
-    private ChatGPTService chatGPTService; // 한글 => 영어 번역을 위한 chat gpt 서비스
+    private ChatGptService chatGPTService; // 한글 => 영어 번역을 위한 chat gpt 서비스
 
     @Value("${azure.cognitiveservice.endpoint}")
     private String cognitiveAzureEndpoint;
@@ -25,7 +25,7 @@ public class TextAnalyticsService {
     @Value("${azure.cognitiveservice.key}")
     private String cognitiveApiKey;
 
-    public TextAnalyticsService(ChatGPTService chatGPTService){
+    public TextAnalyticsService(ChatGptService chatGPTService){
         this.chatGPTService = chatGPTService;
     }
 
@@ -53,6 +53,8 @@ public class TextAnalyticsService {
         });
 
         log.info("키워드 추출 완료");
+
+//        log.info(chatGPTService.generateMessage(inputMessage));
 
         return keyPhrases;
     }


### PR DESCRIPTION
## 📝 설명
- 발송 목적 및 내용 기반 광고 문자 생성 추가
- 뿌리오 API를 통해 발송 완료된 문자 저장 메서드에 `@Transactional` 어노테이션 추가, MessageService에 `@Transactional(readOnly = true)` 추가
- Dalle prompt 좀 더 간단하게 수정했다가 기존의 프롬프트 기반 이미지 생성 결과랑 비슷해서 기존 prompt 유지

##  ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
